### PR TITLE
feat: add icons and points to about section

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -10,23 +10,41 @@ export default function AboutSection() {
         </div>
         <div>
           <h2 className="text-2xl font-semibold mb-4">Sobre mí</h2>
-          <p className="mb-4">Psicóloga Social y psicoanalista</p>
-          <ul className="space-y-2">
-            <li className="flex items-start">
-              <FaBrain className="text-[#8DA977] mr-2 mt-1" />
-              Acompaño procesos de autoconocimiento y reflexión.
+          <p className="mb-6 text-lg">Psicóloga Social y psicoanalista</p>
+          <ul className="space-y-4">
+            <li className="flex items-center">
+              <FaBrain
+                size={22}
+                className="text-[#8DA977] flex-shrink-0 mr-3"
+              />
+              <span>Acompaño procesos de autoconocimiento y reflexión.</span>
             </li>
-            <li className="flex items-start">
-              <FaComments className="text-[#8DA977] mr-2 mt-1" />
-              Trabajo desde la palabra y la escucha para comprender emociones y vínculos.
+            <li className="flex items-center">
+              <FaComments
+                size={22}
+                className="text-[#8DA977] flex-shrink-0 mr-3"
+              />
+              <span>
+                Trabajo desde la palabra y la escucha para comprender emociones
+                y vínculos.
+              </span>
             </li>
-            <li className="flex items-start">
-              <FaUsers className="text-[#8DA977] mr-2 mt-1" />
-              Integro psicoanálisis y psicología social para entender a la persona y su contexto.
+            <li className="flex items-center">
+              <FaUsers
+                size={22}
+                className="text-[#8DA977] flex-shrink-0 mr-3"
+              />
+              <span>
+                Integro psicoanálisis y psicología social para entender a la
+                persona y su contexto.
+              </span>
             </li>
-            <li className="flex items-start">
-              <FaLock className="text-[#8DA977] mr-2 mt-1" />
-              Brindo un espacio seguro y confidencial para explorar y avanzar con conciencia.
+            <li className="flex items-center">
+              <FaLock size={22} className="text-[#8DA977] flex-shrink-0 mr-3" />
+              <span>
+                Brindo un espacio seguro y confidencial para explorar y avanzar
+                con conciencia.
+              </span>
             </li>
           </ul>
         </div>

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { FaBrain, FaComments, FaUsers, FaLock } from "react-icons/fa";
 
 export default function AboutSection() {
   return (
@@ -12,16 +13,20 @@ export default function AboutSection() {
           <p className="mb-4">Psicóloga Social y psicoanalista</p>
           <ul className="space-y-2">
             <li className="flex items-start">
-              <span className="text-[#8DA977] mr-2">✔</span>Soy una psicóloga
-              egresada con orientación psicoanalítica
+              <FaBrain className="text-[#8DA977] mr-2 mt-1" />
+              Acompaño procesos de autoconocimiento y reflexión.
             </li>
             <li className="flex items-start">
-              <span className="text-[#8DA977] mr-2">✔</span>Acompañamiento
-              empático y personalizado
+              <FaComments className="text-[#8DA977] mr-2 mt-1" />
+              Trabajo desde la palabra y la escucha para comprender emociones y vínculos.
             </li>
             <li className="flex items-start">
-              <span className="text-[#8DA977] mr-2">✔</span>Transformación
-              personal
+              <FaUsers className="text-[#8DA977] mr-2 mt-1" />
+              Integro psicoanálisis y psicología social para entender a la persona y su contexto.
+            </li>
+            <li className="flex items-start">
+              <FaLock className="text-[#8DA977] mr-2 mt-1" />
+              Brindo un espacio seguro y confidencial para explorar y avanzar con conciencia.
             </li>
           </ul>
         </div>


### PR DESCRIPTION
## Summary
- enhance About section with four key reflections each paired with a themed icon

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be562a44f083228b39f51280d42b59