### PR TITLE
feat: add scroll animations to sections

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,3 +32,18 @@ html {
 section {
   scroll-margin-top: 10rem;
 }
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.fade-in-up {
+  animation: fadeInUp 0.6s ease-out forwards;
+}

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -1,9 +1,10 @@
 import Image from "next/image";
 import { FaBrain, FaComments, FaUsers, FaLock } from "react-icons/fa";
+import FadeInSection from "./FadeInSection";
 
 export default function AboutSection() {
   return (
-    <section id="sobre-mi" className="px-4 py-14">
+    <FadeInSection id="sobre-mi" className="px-4 py-14">
       <div className="max-w-4xl mx-auto grid md:grid-cols-2 gap-8 items-center">
         <div className="justify-self-center md:justify-self-start">
           <Image src="/leaf.png" alt="Hoja" width={360} height={360} />
@@ -49,6 +50,6 @@ export default function AboutSection() {
           </ul>
         </div>
       </div>
-    </section>
+    </FadeInSection>
   );
 }

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -1,10 +1,11 @@
 import Image from "next/image";
+import FadeInSection from "./FadeInSection";
 
 const WHATSAPP_BASE = "https://wa.me/5493582446357?text=";
 
 export default function ContactSection() {
   return (
-    <section id="contacto" className="px-4 py-16">
+    <FadeInSection id="contacto" className="px-4 py-16">
       <div className="max-w-4xl mx-auto grid md:grid-cols-2 gap-8 items-center">
         <div>
           <h2 className="text-2xl font-semibold mb-4">
@@ -28,6 +29,6 @@ export default function ContactSection() {
           <Image src="/hero2.png" alt="Ilustración" width={320} height={320} />
         </div>
       </div>
-    </section>
+    </FadeInSection>
   );
 }

--- a/src/components/FadeInSection.tsx
+++ b/src/components/FadeInSection.tsx
@@ -12,12 +12,19 @@ export default function FadeInSection({
   useEffect(() => {
     const node = ref.current;
     if (!node) return;
-    const observer = new IntersectionObserver(([entry]) => {
-      if (entry.isIntersecting) {
-        node.classList.add("fade-in-up");
-        observer.disconnect();
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          node.classList.add("fade-in-up");
+          observer.disconnect();
+        }
+      },
+      {
+        // Trigger slightly before the element fully enters the viewport so
+        // animations are visible on smaller mobile screens
+        rootMargin: "0px 0px -10% 0px",
       }
-    });
+    );
     observer.observe(node);
     return () => observer.disconnect();
   }, []);

--- a/src/components/FadeInSection.tsx
+++ b/src/components/FadeInSection.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { ComponentProps, useEffect, useRef } from "react";
+
+export default function FadeInSection({
+  children,
+  className = "",
+  ...props
+}: ComponentProps<"section">) {
+  const ref = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        node.classList.add("fade-in-up");
+        observer.disconnect();
+      }
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <section ref={ref} className={`opacity-0 ${className}`} {...props}>
+      {children}
+    </section>
+  );
+}
+

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,8 +1,9 @@
 import Image from "next/image";
+import FadeInSection from "./FadeInSection";
 
 export default function HeroSection() {
   return (
-    <section id="inicio" className="bg-[#F3E8E2] py-16 px-4">
+    <FadeInSection id="inicio" className="bg-[#F3E8E2] py-16 px-4">
       <div className="max-w-5xl mx-auto grid md:grid-cols-2 gap-8 items-center">
         <div>
           <h1 className="text-3xl md:text-5xl font-semibold leading-tight mb-4">
@@ -25,6 +26,6 @@ export default function HeroSection() {
           <Image src="/hero.png" alt="Ilustración" width={320} height={320} />
         </div>
       </div>
-    </section>
+    </FadeInSection>
   );
 }

--- a/src/components/MethodSection.tsx
+++ b/src/components/MethodSection.tsx
@@ -1,6 +1,8 @@
+import FadeInSection from "./FadeInSection";
+
 export default function MethodSection() {
   return (
-    <section id="metodo" className="bg-[#F3E8E2] px-4 py-16">
+    <FadeInSection id="metodo" className="bg-[#F3E8E2] px-4 py-16">
       <div className="max-w-4xl mx-auto">
         <h2 className="text-2xl font-semibold text-center mb-8">
           Mi método de trabajo
@@ -24,6 +26,6 @@ export default function MethodSection() {
           <strong>autoconocimiento</strong>.
         </p>
       </div>
-    </section>
+    </FadeInSection>
   );
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -82,6 +82,7 @@ export default function Navbar() {
             className="rounded-full border border-[#D8CABB] bg-white/70 p-2 text-[#4A3B37] shadow-sm transition-colors hover:bg-[#4A3B37] hover:text-[#F5F0E8] md:hidden"
             onClick={() => setIsMenuOpen((prev) => !prev)}
             aria-label="Toggle menu"
+            aria-expanded={isMenuOpen}
           >
             {isMenuOpen ? (
               <X className="h-5 w-5" />
@@ -92,8 +93,14 @@ export default function Navbar() {
         </div>
 
         {/* Mobile Navigation */}
-        {isMenuOpen && (
-          <div className="flex flex-col items-center gap-3 pb-4 md:hidden">
+        <div
+          className={`md:hidden overflow-hidden transition-all duration-300 ${
+            isMenuOpen
+              ? "max-h-96 opacity-100"
+              : "max-h-0 opacity-0 pointer-events-none"
+          }`}
+        >
+          <div className="flex flex-col items-center gap-3 pb-4">
             {navItems.map((item) => (
               <a
                 key={item.href}
@@ -133,7 +140,7 @@ export default function Navbar() {
               <span className="font-medium">WhatsApp</span>
             </Link>
           </div>
-        )}
+        </div>
       </div>
     </nav>
   );

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import Image from "next/image";
+import FadeInSection from "./FadeInSection";
 
 const WHATSAPP_BASE = "https://wa.me/5493582446357?text=";
 
@@ -42,7 +43,7 @@ const cards = [
 
 export default function ServicesSection() {
   return (
-    <section id="servicios" className="px-4 py-16 bg-[#FBF6EF]">
+    <FadeInSection id="servicios" className="px-4 py-16 bg-[#FBF6EF]">
       <div className="max-w-6xl mx-auto">
         <h2 className="text-3xl font-semibold text-center text-[#5C3A2E] mb-12">
           Servicios
@@ -103,6 +104,6 @@ export default function ServicesSection() {
           ))}
         </div>
       </div>
-    </section>
+    </FadeInSection>
   );
 }


### PR DESCRIPTION
## Summary
- animate secciones de inicio, sobre mí, servicios, método y contacto al aparecer
- añade FadeInSection con IntersectionObserver y estilos `fade-in-up`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf47e991d483229e6b06b6e10483b7