### PR TITLE
feat: add framer-motion animations

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "next": "15.5.2",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-icons": "^5.5.0"
+    "react-icons": "^5.5.0",
+    "framer-motion": "^11.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,10 +1,17 @@
+"use client";
+
+import { motion } from "framer-motion";
 import Image from "next/image";
 
 export default function HeroSection() {
   return (
     <section id="inicio" className="bg-[#F3E8E2] py-16 px-4">
       <div className="max-w-5xl mx-auto grid md:grid-cols-2 gap-8 items-center">
-        <div>
+        <motion.div
+          initial={{ opacity: 0, x: -50 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.6 }}
+        >
           <h1 className="text-3xl md:text-5xl font-semibold leading-tight mb-4">
             Psicología Social & Psicoanálisis para tu bienestar
           </h1>
@@ -20,10 +27,15 @@ export default function HeroSection() {
           >
             Agenda tu sesión
           </a>
-        </div>
-        <div className="justify-self-center">
+        </motion.div>
+        <motion.div
+          className="justify-self-center"
+          initial={{ opacity: 0, x: 50 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.6, delay: 0.2 }}
+        >
           <Image src="/hero.png" alt="Ilustración" width={320} height={320} />
-        </div>
+        </motion.div>
       </div>
     </section>
   );

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -1,6 +1,7 @@
 // app/components/ServicesSection.tsx
 "use client";
 
+import { motion } from "framer-motion";
 import Image from "next/image";
 
 const WHATSAPP_BASE = "https://wa.me/5493582446357?text=";
@@ -49,9 +50,13 @@ export default function ServicesSection() {
         </h2>
 
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-          {cards.map((c) => (
-            <article
+          {cards.map((c, i) => (
+            <motion.article
               key={c.title}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.4, delay: i * 0.1 }}
               className="
                 group relative flex flex-col p-6 bg-white
                 rounded-2xl border border-[#E18A63]
@@ -99,7 +104,7 @@ export default function ServicesSection() {
 
               {/* borde interior */}
               <div className="pointer-events-none absolute inset-0 rounded-2xl ring-1 ring-[#E18A63]/20" />
-            </article>
+            </motion.article>
           ))}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- animate hero text and image using framer-motion
- fade in service cards on scroll with framer-motion
- declare framer-motion dependency

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf4ceded1083229aed464ca0e7c7cb